### PR TITLE
Simplify xor key generation

### DIFF
--- a/ptfformat.cc
+++ b/ptfformat.cc
@@ -102,7 +102,7 @@ PTFFormat::load(std::string path, int64_t targetsr) {
 
 	fseek(fp, 0, SEEK_END);
 	len = ftell(fp);
-	if (len < 0x13) {
+	if (len < 0x14) {
 		fclose(fp);
 		return -1;
 	}

--- a/ptfformat.h
+++ b/ptfformat.h
@@ -109,6 +109,8 @@ public:
 	int64_t sessionrate;
 	int64_t targetrate;
 	uint8_t version;
+	uint8_t *product;
+
 
 	unsigned char c0;
 	unsigned char c1;
@@ -118,8 +120,8 @@ public:
 private:
 	bool foundin(std::string haystack, std::string needle);
 	int parse(void);
-	void unxor10(void);
-	void unxor_ptx_to_ptf(void);
+	bool parse_version();
+	uint8_t gen_xor_delta(uint8_t xor_value, uint8_t mul, bool negative);
 	void setrates(void);
 	void parse5header(void);
 	void parse7header(void);
@@ -132,7 +134,6 @@ private:
 	void parseaudio5(void);
 	void parseaudio(void);
 	void resort(std::vector<wav_t>& ws);
-	uint8_t mostfrequent(uint32_t start, uint32_t stop);
 	std::vector<wav_t> actualwavs;
 	float ratefactor;
 	std::string extension;


### PR DESCRIPTION
I've simplified your xor decryption code.
I realized that the two bytes at offset 0x12 and 0x13 are encryption identification.

The first byte is the type of encryption.
I've only seen the values 0x01 and 0x05.
0x01 is the encryption scheme used for PT8-9, and 0x05 is the scheme used from PT10 and later.

The next value is part of a lookup table, and the position of this value in the lut is the delta that is used to create the xor key.
For PT10 - PT12, this lut looks like this:
```
0x0000: 0x00 0x0B 0x16 0x21 0x2C 0x37 0x42 0x4D 0x58 0x63 0x6E 0x79 0x84 0x8F 0x9A 0xA5  
0x0010: 0xB0 0xBB 0xC6 0xD1 0xDC 0xE7 0xF2 0xFD 0x08 0x13 0x1E 0x29 0x34 0x3F 0x4A 0x55  
0x0020: 0x60 0x6B 0x76 0x81 0x8C 0x97 0xA2 0xAD 0xB8 0xC3 0xCE 0xD9 0xE4 0xEF 0xFA 0x05  
0x0030: 0x10 0x1B 0x26 0x31 0x3C 0x47 0x52 0x5D 0x68 0x73 0x7E 0x89 0x94 0x9F 0xAA 0xB5  
0x0040: 0xC0 0xCB 0xD6 0xE1 0xEC 0xF7 0x02 0x0D 0x18 0x23 0x2E 0x39 0x44 0x4F 0x5A 0x65  
0x0050: 0x70 0x7B 0x86 0x91 0x9C 0xA7 0xB2 0xBD 0xC8 0xD3 0xDE 0xE9 0xF4 0xFF 0x0A 0x15  
0x0060: 0x20 0x2B 0x36 0x41 0x4C 0x57 0x62 0x6D 0x78 0x83 0x8E 0x99 0xA4 0xAF 0xBA 0xC5  
0x0070: 0xD0 0xDB 0xE6 0xF1 0xFC 0x07 0x12 0x1D 0x28 0x33 0x3E 0x49 0x54 0x5F 0x6A 0x75  
0x0080: 0x80 0x8B 0x96 0xA1 0xAC 0xB7 0xC2 0xCD 0xD8 0xE3 0xEE 0xF9 0x04 0x0F 0x1A 0x25  
0x0090: 0x30 0x3B 0x46 0x51 0x5C 0x67 0x72 0x7D 0x88 0x93 0x9E 0xA9 0xB4 0xBF 0xCA 0xD5  
0x00A0: 0xE0 0xEB 0xF6 0x01 0x0C 0x17 0x22 0x2D 0x38 0x43 0x4E 0x59 0x64 0x6F 0x7A 0x85  
0x00B0: 0x90 0x9B 0xA6 0xB1 0xBC 0xC7 0xD2 0xDD 0xE8 0xF3 0xFE 0x09 0x14 0x1F 0x2A 0x35  
0x00C0: 0x40 0x4B 0x56 0x61 0x6C 0x77 0x82 0x8D 0x98 0xA3 0xAE 0xB9 0xC4 0xCF 0xDA 0xE5  
0x00D0: 0xF0 0xFB 0x06 0x11 0x1C 0x27 0x32 0x3D 0x48 0x53 0x5E 0x69 0x74 0x7F 0x8A 0x95  
0x00E0: 0xA0 0xAB 0xB6 0xC1 0xCC 0xD7 0xE2 0xED 0xF8 0x03 0x0E 0x19 0x24 0x2F 0x3A 0x45  
0x00F0: 0x50 0x5B 0x66 0x71 0x7C 0x87 0x92 0x9D 0xA8 0xB3 0xBE 0xC9 0xD4 0xDF 0xEA 0xF5  
```

So if the value at offset 0x13 is 0x21, we can see that it has index 0x03 in the lut.
Since this is for PT10-12, we have to take the negative of this number.
Then we generate the xor_key by doing:
```
for (i=0; i < 128; i++) {
    xxor[i] = (i * (-3)) & 0xff;
}
```

I've tested that this works with a selection of files from PT8 to PT12.
Hope you find some use for this code :)

